### PR TITLE
Corsawarenegotiatesecurityfilter

### DIFF
--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/CorsPreFlightAwareNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/CorsPreFlightAwareNegotiateSecurityFilter.java
@@ -1,0 +1,66 @@
+package waffle.servlet;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import waffle.util.CorsPreFlightHeaders;
+
+public class CorsPreFlightAwareNegotiateSecurityFilter extends NegotiateSecurityFilter implements Filter {
+    /** The Constant LOGGER. */
+    private static final Logger LOGGER = LoggerFactory.getLogger(NegotiateSecurityFilter.class);
+
+    /**
+     * Instantiates a new negotiate security filter.
+     */
+    public CorsPreFlightAwareNegotiateSecurityFilter() {
+        CorsPreFlightAwareNegotiateSecurityFilter.LOGGER
+                .debug("[waffle.servlet.CorsPreFlightAwareNegotiateSecurityFilter] loaded");
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        super.init(filterConfig);
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        final HttpServletRequest sreq = (HttpServletRequest) request;
+
+        if (isPreFlightRequest(sreq)) {
+            chain.doFilter(request, response);
+        } else {
+            super.doFilter(request, response, chain);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+    }
+
+    private boolean isPreFlightRequest(HttpServletRequest request) {
+
+        final String preflightAttributeValue = "PRE_FLIGHT";
+        final String corsRequestType = (String) request.getAttribute("cors.request.type");
+
+        // it has to be an OPTIONS Method to be a PreFlight Request
+        if (!request.getMethod().equalsIgnoreCase("OPTIONS")) {
+            return false;
+        }
+        // let an HttpServletFilter already add the Attribute "PRE_FLIGHT" for the value cors.request.type
+        if (corsRequestType != null && corsRequestType.equalsIgnoreCase(preflightAttributeValue)) {
+            return true;
+        } else {
+            return CorsPreFlightHeaders.containsAllPreFlightHeaders(request);
+        }
+    }
+}

--- a/Source/JNA/waffle-jna/src/main/java/waffle/servlet/CorsPreFlightAwareNegotiateSecurityFilter.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/servlet/CorsPreFlightAwareNegotiateSecurityFilter.java
@@ -27,24 +27,37 @@ public class CorsPreFlightAwareNegotiateSecurityFilter extends NegotiateSecurity
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         super.init(filterConfig);
+        CorsPreFlightAwareNegotiateSecurityFilter.LOGGER
+                .debug("[waffle.servlet.CorsPreFlightAwareNegotiateSecurityFilter] Loaded");
+
     }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 
+        CorsPreFlightAwareNegotiateSecurityFilter.LOGGER
+                .debug("[waffle.servlet.CorsPreFlightAwareNegotiateSecurityFilter] Filtering");
+        
         final HttpServletRequest sreq = (HttpServletRequest) request;
 
         if (isPreFlightRequest(sreq)) {
+            CorsPreFlightAwareNegotiateSecurityFilter.LOGGER
+                .debug("[waffle.servlet.CorsPreFlightAwareNegotiateSecurityFilter] Authentication Skipped");
             chain.doFilter(request, response);
         } else {
             super.doFilter(request, response, chain);
+                    CorsPreFlightAwareNegotiateSecurityFilter.LOGGER
+                .debug("[waffle.servlet.CorsPreFlightAwareNegotiateSecurityFilter] Authentication Completed");
         }
     }
 
     @Override
     public void destroy() {
         super.destroy();
+        CorsPreFlightAwareNegotiateSecurityFilter.LOGGER
+                .debug("[waffle.servlet.CorsPreFlightAwareNegotiateSecurityFilter] unloaded");
+
     }
 
     private boolean isPreFlightRequest(HttpServletRequest request) {

--- a/Source/JNA/waffle-jna/src/main/java/waffle/util/CorsPreFlightHeaders.java
+++ b/Source/JNA/waffle-jna/src/main/java/waffle/util/CorsPreFlightHeaders.java
@@ -1,0 +1,42 @@
+/**
+ * Waffle (https://github.com/Waffle/waffle)
+ *
+ * Copyright (c) 2010-2018 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Contributors: Application Security, Inc.
+ */
+package waffle.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ *
+ */
+public class CorsPreFlightHeaders {
+
+    final private static List<String> EXPECTED_PRE_FLIGHT_HEADERS;
+    static {
+        EXPECTED_PRE_FLIGHT_HEADERS = new ArrayList<String>() {
+            {
+                add("Access-Control-Request-Method");
+                add("Access-Control-Request-Headers");
+                add("Origin");
+            }
+        };
+    }
+
+    public static boolean containsAllPreFlightHeaders(HttpServletRequest request) {
+        for (String header : CorsPreFlightHeaders.EXPECTED_PRE_FLIGHT_HEADERS) {
+            if (request.getHeader(header) == null)
+                return false;
+        }
+        return true;
+    }
+}

--- a/Source/JNA/waffle-jna/src/test/java/waffle/util/CorsPreFlightHeadersTest.java
+++ b/Source/JNA/waffle-jna/src/test/java/waffle/util/CorsPreFlightHeadersTest.java
@@ -1,0 +1,747 @@
+/**
+ * Waffle (https://github.com/Waffle/waffle)
+ *
+ * Copyright (c) 2010-2018 Application Security, Inc.
+ *
+ * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
+ * Public License v1.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Contributors: Application Security, Inc.
+ */
+package waffle.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.Principal;
+import java.util.*;
+
+import javax.servlet.*;
+import javax.servlet.http.*;
+
+import org.junit.jupiter.api.Test;
+
+class CorsPreFlightHeadersTest {
+
+    @Test
+    void testExpectedCorsPreFlightHeadersPresent() {
+        HttpServletRequest req = new HttpServletRequest() {
+            Map<String, String> headers = new HashMap<String, String>() {
+                {
+                    put("Access-Control-Request-Method", "LOGIN");
+                    put("Access-Control-Request-Headers", "x-request-for");
+                    put("Origin", "https://theorigin.localhost");
+                }
+            };
+
+            @Override
+            public String getAuthType() {
+                return null;
+            }
+
+            @Override
+            public Cookie[] getCookies() {
+                return new Cookie[0];
+            }
+
+            @Override
+            public long getDateHeader(String s) {
+                return 0;
+            }
+
+            @Override
+            public String getHeader(String s) {
+                return (String) headers.get(s);
+            }
+
+            @Override
+            public Enumeration<String> getHeaders(String s) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getHeaderNames() {
+                return null;
+            }
+
+            @Override
+            public int getIntHeader(String s) {
+                return 0;
+            }
+
+            @Override
+            public String getMethod() {
+                return null;
+            }
+
+            @Override
+            public String getPathInfo() {
+                return null;
+            }
+
+            @Override
+            public String getPathTranslated() {
+                return null;
+            }
+
+            @Override
+            public String getContextPath() {
+                return null;
+            }
+
+            @Override
+            public String getQueryString() {
+                return null;
+            }
+
+            @Override
+            public String getRemoteUser() {
+                return null;
+            }
+
+            @Override
+            public boolean isUserInRole(String s) {
+                return false;
+            }
+
+            @Override
+            public Principal getUserPrincipal() {
+                return null;
+            }
+
+            @Override
+            public String getRequestedSessionId() {
+                return null;
+            }
+
+            @Override
+            public String getRequestURI() {
+                return null;
+            }
+
+            @Override
+            public StringBuffer getRequestURL() {
+                return null;
+            }
+
+            @Override
+            public String getServletPath() {
+                return null;
+            }
+
+            @Override
+            public HttpSession getSession(boolean b) {
+                return null;
+            }
+
+            @Override
+            public HttpSession getSession() {
+                return null;
+            }
+
+            @Override
+            public String changeSessionId() {
+                return null;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdValid() {
+                return false;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdFromCookie() {
+                return false;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdFromURL() {
+                return false;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdFromUrl() {
+                return false;
+            }
+
+            @Override
+            public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException {
+                return false;
+            }
+
+            @Override
+            public void login(String s, String s1) throws ServletException {
+
+            }
+
+            @Override
+            public void logout() throws ServletException {
+
+            }
+
+            @Override
+            public Collection<Part> getParts() throws IOException, ServletException {
+                return null;
+            }
+
+            @Override
+            public Part getPart(String s) throws IOException, ServletException {
+                return null;
+            }
+
+            @Override
+            public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
+                return null;
+            }
+
+            @Override
+            public Object getAttribute(String s) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getAttributeNames() {
+                return null;
+            }
+
+            @Override
+            public String getCharacterEncoding() {
+                return null;
+            }
+
+            @Override
+            public void setCharacterEncoding(String s) throws UnsupportedEncodingException {
+
+            }
+
+            @Override
+            public int getContentLength() {
+                return 0;
+            }
+
+            @Override
+            public long getContentLengthLong() {
+                return 0;
+            }
+
+            @Override
+            public String getContentType() {
+                return null;
+            }
+
+            @Override
+            public ServletInputStream getInputStream() throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getParameter(String s) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getParameterNames() {
+                return null;
+            }
+
+            @Override
+            public String[] getParameterValues(String s) {
+                return new String[0];
+            }
+
+            @Override
+            public Map<String, String[]> getParameterMap() {
+                return null;
+            }
+
+            @Override
+            public String getProtocol() {
+                return null;
+            }
+
+            @Override
+            public String getScheme() {
+                return null;
+            }
+
+            @Override
+            public String getServerName() {
+                return null;
+            }
+
+            @Override
+            public int getServerPort() {
+                return 0;
+            }
+
+            @Override
+            public BufferedReader getReader() throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getRemoteAddr() {
+                return null;
+            }
+
+            @Override
+            public String getRemoteHost() {
+                return null;
+            }
+
+            @Override
+            public void setAttribute(String s, Object o) {
+
+            }
+
+            @Override
+            public void removeAttribute(String s) {
+
+            }
+
+            @Override
+            public Locale getLocale() {
+                return null;
+            }
+
+            @Override
+            public Enumeration<Locale> getLocales() {
+                return null;
+            }
+
+            @Override
+            public boolean isSecure() {
+                return false;
+            }
+
+            @Override
+            public RequestDispatcher getRequestDispatcher(String s) {
+                return null;
+            }
+
+            @Override
+            public String getRealPath(String s) {
+                return null;
+            }
+
+            @Override
+            public int getRemotePort() {
+                return 0;
+            }
+
+            @Override
+            public String getLocalName() {
+                return null;
+            }
+
+            @Override
+            public String getLocalAddr() {
+                return null;
+            }
+
+            @Override
+            public int getLocalPort() {
+                return 0;
+            }
+
+            @Override
+            public ServletContext getServletContext() {
+                return null;
+            }
+
+            @Override
+            public AsyncContext startAsync() throws IllegalStateException {
+                return null;
+            }
+
+            @Override
+            public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+                    throws IllegalStateException {
+                return null;
+            }
+
+            @Override
+            public boolean isAsyncStarted() {
+                return false;
+            }
+
+            @Override
+            public boolean isAsyncSupported() {
+                return false;
+            }
+
+            @Override
+            public AsyncContext getAsyncContext() {
+                return null;
+            }
+
+            @Override
+            public DispatcherType getDispatcherType() {
+                return null;
+            }
+        };
+        assertTrue(CorsPreFlightHeaders.containsAllPreFlightHeaders(req));
+    }
+
+    @Test
+    void testExpectedCorsPreFlightHeadersIncomplete() {
+        HttpServletRequest req = new HttpServletRequest() {
+            Map<String, String> headers = new HashMap<String, String>() {
+                {
+                    put("Access-Control-Request-Method", "LOGIN");
+                    put("Access-Control-Request-Headers", "x-request-for");
+                }
+            };
+
+            @Override
+            public String getAuthType() {
+                return null;
+            }
+
+            @Override
+            public Cookie[] getCookies() {
+                return new Cookie[0];
+            }
+
+            @Override
+            public long getDateHeader(String s) {
+                return 0;
+            }
+
+            @Override
+            public String getHeader(String s) {
+                return (String) headers.get(s);
+            }
+
+            @Override
+            public Enumeration<String> getHeaders(String s) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getHeaderNames() {
+                return null;
+            }
+
+            @Override
+            public int getIntHeader(String s) {
+                return 0;
+            }
+
+            @Override
+            public String getMethod() {
+                return null;
+            }
+
+            @Override
+            public String getPathInfo() {
+                return null;
+            }
+
+            @Override
+            public String getPathTranslated() {
+                return null;
+            }
+
+            @Override
+            public String getContextPath() {
+                return null;
+            }
+
+            @Override
+            public String getQueryString() {
+                return null;
+            }
+
+            @Override
+            public String getRemoteUser() {
+                return null;
+            }
+
+            @Override
+            public boolean isUserInRole(String s) {
+                return false;
+            }
+
+            @Override
+            public Principal getUserPrincipal() {
+                return null;
+            }
+
+            @Override
+            public String getRequestedSessionId() {
+                return null;
+            }
+
+            @Override
+            public String getRequestURI() {
+                return null;
+            }
+
+            @Override
+            public StringBuffer getRequestURL() {
+                return null;
+            }
+
+            @Override
+            public String getServletPath() {
+                return null;
+            }
+
+            @Override
+            public HttpSession getSession(boolean b) {
+                return null;
+            }
+
+            @Override
+            public HttpSession getSession() {
+                return null;
+            }
+
+            @Override
+            public String changeSessionId() {
+                return null;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdValid() {
+                return false;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdFromCookie() {
+                return false;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdFromURL() {
+                return false;
+            }
+
+            @Override
+            public boolean isRequestedSessionIdFromUrl() {
+                return false;
+            }
+
+            @Override
+            public boolean authenticate(HttpServletResponse httpServletResponse) throws IOException, ServletException {
+                return false;
+            }
+
+            @Override
+            public void login(String s, String s1) throws ServletException {
+
+            }
+
+            @Override
+            public void logout() throws ServletException {
+
+            }
+
+            @Override
+            public Collection<Part> getParts() throws IOException, ServletException {
+                return null;
+            }
+
+            @Override
+            public Part getPart(String s) throws IOException, ServletException {
+                return null;
+            }
+
+            @Override
+            public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass) throws IOException, ServletException {
+                return null;
+            }
+
+            @Override
+            public Object getAttribute(String s) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getAttributeNames() {
+                return null;
+            }
+
+            @Override
+            public String getCharacterEncoding() {
+                return null;
+            }
+
+            @Override
+            public void setCharacterEncoding(String s) throws UnsupportedEncodingException {
+
+            }
+
+            @Override
+            public int getContentLength() {
+                return 0;
+            }
+
+            @Override
+            public long getContentLengthLong() {
+                return 0;
+            }
+
+            @Override
+            public String getContentType() {
+                return null;
+            }
+
+            @Override
+            public ServletInputStream getInputStream() throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getParameter(String s) {
+                return null;
+            }
+
+            @Override
+            public Enumeration<String> getParameterNames() {
+                return null;
+            }
+
+            @Override
+            public String[] getParameterValues(String s) {
+                return new String[0];
+            }
+
+            @Override
+            public Map<String, String[]> getParameterMap() {
+                return null;
+            }
+
+            @Override
+            public String getProtocol() {
+                return null;
+            }
+
+            @Override
+            public String getScheme() {
+                return null;
+            }
+
+            @Override
+            public String getServerName() {
+                return null;
+            }
+
+            @Override
+            public int getServerPort() {
+                return 0;
+            }
+
+            @Override
+            public BufferedReader getReader() throws IOException {
+                return null;
+            }
+
+            @Override
+            public String getRemoteAddr() {
+                return null;
+            }
+
+            @Override
+            public String getRemoteHost() {
+                return null;
+            }
+
+            @Override
+            public void setAttribute(String s, Object o) {
+
+            }
+
+            @Override
+            public void removeAttribute(String s) {
+
+            }
+
+            @Override
+            public Locale getLocale() {
+                return null;
+            }
+
+            @Override
+            public Enumeration<Locale> getLocales() {
+                return null;
+            }
+
+            @Override
+            public boolean isSecure() {
+                return false;
+            }
+
+            @Override
+            public RequestDispatcher getRequestDispatcher(String s) {
+                return null;
+            }
+
+            @Override
+            public String getRealPath(String s) {
+                return null;
+            }
+
+            @Override
+            public int getRemotePort() {
+                return 0;
+            }
+
+            @Override
+            public String getLocalName() {
+                return null;
+            }
+
+            @Override
+            public String getLocalAddr() {
+                return null;
+            }
+
+            @Override
+            public int getLocalPort() {
+                return 0;
+            }
+
+            @Override
+            public ServletContext getServletContext() {
+                return null;
+            }
+
+            @Override
+            public AsyncContext startAsync() throws IllegalStateException {
+                return null;
+            }
+
+            @Override
+            public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+                    throws IllegalStateException {
+                return null;
+            }
+
+            @Override
+            public boolean isAsyncStarted() {
+                return false;
+            }
+
+            @Override
+            public boolean isAsyncSupported() {
+                return false;
+            }
+
+            @Override
+            public AsyncContext getAsyncContext() {
+                return null;
+            }
+
+            @Override
+            public DispatcherType getDispatcherType() {
+                return null;
+            }
+        };
+        assertTrue(!CorsPreFlightHeaders.containsAllPreFlightHeaders(req));
+    }
+}


### PR DESCRIPTION
Added CorsPreFlightAwareNegotiateSecurityFilter which extends NegotiateSecurityFilter

The new ServletFilter will skip authentication for requests that have an OPTIONS Method and non empty CORS headers
Access-Control-Request-Method
Access-Control-Request-Headers
Origin